### PR TITLE
Add ability to select start of week for league stats, to allow for qu…

### DIFF
--- a/src/components/league-rankings.js
+++ b/src/components/league-rankings.js
@@ -25,7 +25,7 @@ export default class LeagueRankings extends React.Component {
     this.setState({ data_to_display: e.target.value });
   };
 
-  static columnHeaders = [
+  columnHeaders = [
     { text: 'Name', sortColumn: 'name', sortDirection: 'down' },
     {
       text: 'Two Weeks Ago',
@@ -44,7 +44,29 @@ export default class LeagueRankings extends React.Component {
     }
   ];
 
+  updateColumnHeaders() {
+    this.columnHeaders[1].text =
+      'Two Weeks Ago (' +
+      this.props.last_last_week_date_range_start +
+      '-' +
+      this.props.last_last_week_date_range_end +
+      ')';
+    this.columnHeaders[2].text =
+      'Last Week (' +
+      this.props.last_week_date_range_start +
+      '-' +
+      this.props.last_week_date_range_end +
+      ')';
+    this.columnHeaders[3].text =
+      'This Week (' +
+      this.props.this_week_date_range_start +
+      '-' +
+      this.props.this_week_date_range_end +
+      ')';
+  }
+
   render() {
+    this.updateColumnHeaders();
     const calcStats = this.props.calcStats;
     const snapshot_table = {};
     // should be three iterations, starting with this week
@@ -207,7 +229,7 @@ export default class LeagueRankings extends React.Component {
               <Table striped bordered condensed hover>
                 <thead>
                   <tr>
-                    {LeagueRankings.columnHeaders.map(header =>
+                    {this.columnHeaders.map(header =>
                       <TableHeader
                         key={header.text}
                         setState={this.setState.bind(this)}

--- a/src/meta.css
+++ b/src/meta.css
@@ -1,0 +1,4 @@
+.league_top .text {
+  padding-inline-end: 5px;
+  padding-inline-start: 10px;
+}

--- a/src/meta.js
+++ b/src/meta.js
@@ -16,6 +16,8 @@ import { event } from './analytics';
 import update from 'immutability-helper';
 import moment from 'moment';
 
+import './meta.css';
+
 const { ipcRenderer } = require('electron');
 
 const Meta = () =>
@@ -44,8 +46,15 @@ class MetaContainer extends React.Component {
   }
 
   getMetaRequest() {
-    let endUtc = moment().startOf('day');
-    let startUtc = moment();
+    let endUtc = moment().utc().startOf('day');
+    let startUtc = moment().utc();
+    if (
+      startUtc.hour() < 2 ||
+      (startUtc.hour() === 2 && startUtc.minute() < 31)
+    ) {
+      startUtc.subtract(3, 'hours');
+      endUtc.subtract(3, 'hours');
+    }
     // gathers three weeks of data, where 'this week' may only be today
     if (startUtc.day() < this.state.next_desired_start_of_week) {
       startUtc.day(this.state.next_desired_start_of_week).subtract(1, 'week');
@@ -106,7 +115,10 @@ class MetaContainer extends React.Component {
 
   getWeekIndex(date, start_of_week) {
     let input_moment = moment(date);
-    let now = moment();
+    let now = moment().utc();
+    if (now.hour() < 2 || (now.hour() === 2 && now.minute() < 31)) {
+      now.subtract(3, 'hours');
+    }
     if (now.day() < start_of_week) {
       now.day(start_of_week).subtract(1, 'week');
     } else {
@@ -192,7 +204,7 @@ class MetaContainer extends React.Component {
   render() {
     return (
       <div>
-        <Form inline>
+        <Form inline className="league_top">
           <ButtonToolbar>
             <Button
               bsStyle="primary"
@@ -259,7 +271,7 @@ class MetaContainer extends React.Component {
               </Button>
             </ButtonGroup>
             <FormGroup controlId="startOfWeekSelect">
-              <ControlLabel> Start of Week:</ControlLabel>
+              <ControlLabel className="text">Start of Week (UTC):</ControlLabel>
               <FormControl
                 onChange={this.setDesiredStartDayOfWeek}
                 componentClass="select"

--- a/src/meta.js
+++ b/src/meta.js
@@ -41,6 +41,13 @@ class MetaContainer extends React.Component {
 
   desired_start_of_week = 1;
 
+  this_week_date_range_start = '';
+  this_week_date_range_end = '';
+  last_week_date_range_start = '';
+  last_week_date_range_end = '';
+  last_last_week_date_range_start = '';
+  last_last_week_date_range_end = '';
+
   componentDidMount() {
     ipcRenderer.on('apiData', this.getMetaLoad);
   }
@@ -63,6 +70,8 @@ class MetaContainer extends React.Component {
       startUtc.day(this.state.next_desired_start_of_week);
     }
     startUtc.startOf('day').subtract(2, 'week');
+
+    this.this_week_date_range_end = endUtc.format('DMMM');
 
     while (endUtc.diff(startUtc, 'days') >= 0) {
       for (let i = 0; i < 24; i += 2) {
@@ -126,10 +135,19 @@ class MetaContainer extends React.Component {
       now.day(start_of_week);
     }
     if (input_moment.isSameOrAfter(now.startOf('day'))) {
+      this.this_week_date_range_start = input_moment.format('DMMM');
+      this.last_week_date_range_end = input_moment
+        .subtract(1, 'day')
+        .format('DMMM');
       return 0;
     } else if (input_moment.isSameOrAfter(now.subtract(1, 'week'))) {
+      this.last_week_date_range_start = input_moment.format('DMMM');
+      this.last_last_week_date_range_end = input_moment
+        .subtract(1, 'day')
+        .format('DMMM');
       return 1;
     } else {
+      this.last_last_week_date_range_start = input_moment.format('DMMM');
       return 2;
     }
   }
@@ -294,6 +312,12 @@ class MetaContainer extends React.Component {
           handleChange={this.handleChange}
           calcStats={this.getCalculatedWeaponStats(this.state.league_dict)}
           title={this.state.title}
+          this_week_date_range_start={this.this_week_date_range_start}
+          this_week_date_range_end={this.this_week_date_range_end}
+          last_week_date_range_start={this.last_week_date_range_start}
+          last_week_date_range_end={this.last_week_date_range_end}
+          last_last_week_date_range_start={this.last_last_week_date_range_start}
+          last_last_week_date_range_end={this.last_last_week_date_range_end}
         />
       </div>
     );


### PR DESCRIPTION
This lets you pick the start of week, either for your preference or for doing analysis just on the last few days (for example after patch 1.3.0).   Still not super precise, but still prevents someone from doing too crazy of an API volley.

![image](https://user-images.githubusercontent.com/6663484/30251657-bde2ae94-9629-11e7-9f76-d5c9889eb504.png)
