### PR TITLE
Fix sorting algorithm and clean up stage card

### DIFF
--- a/src/components/sort-array.js
+++ b/src/components/sort-array.js
@@ -25,13 +25,18 @@ export function sort(array, sortColumn, sortDirection, convertFunc) {
         ? convertFunc(getValue(b, sortColumn))
         : getValue(b, sortColumn);
 
-    if (valA > valB) {
-      return sortDirection === 'up' ? -1 : 1;
+    if (!isFinite(valA) && !isFinite(valB)) {
+      return 0;
     }
-    if (valA < valB) {
-      return sortDirection === 'up' ? 1 : -1;
+    if (!isFinite(valA)) {
+      return 1;
     }
-    return 0;
+    if (!isFinite(valB)) {
+      return -1;
+    }
+
+    return valB - valA;
   });
+
   return array;
 }

--- a/src/components/sort-array.js
+++ b/src/components/sort-array.js
@@ -25,17 +25,26 @@ export function sort(array, sortColumn, sortDirection, convertFunc) {
         ? convertFunc(getValue(b, sortColumn))
         : getValue(b, sortColumn);
 
-    if (!isFinite(valA) && !isFinite(valB)) {
-      return 0;
-    }
-    if (!isFinite(valA)) {
-      return 1;
-    }
-    if (!isFinite(valB)) {
-      return -1;
+    if (typeof valA !== 'string' && valB !== 'string') {
+      if (!isFinite(valA) && !isFinite(valB)) {
+        return 0;
+      }
+      if (!isFinite(valA)) {
+        return 1;
+      }
+      if (!isFinite(valB)) {
+        return -1;
+      }
     }
 
-    return valB - valA;
+    if (valA > valB) {
+      return sortDirection === 'up' ? -1 : 1;
+    }
+    if (valA < valB) {
+      return sortDirection === 'up' ? 1 : -1;
+    }
+
+    return 0;
   });
 
   return array;

--- a/src/components/stage-card.js
+++ b/src/components/stage-card.js
@@ -231,27 +231,37 @@ class StageCard extends React.Component {
                         <td>{stage.stage.name}</td>
                         <td>
                           {this.state.percent
-                            ? `${stage.area_percent.toFixed(2)}`
+                            ? isFinite(stage.area_percent)
+                              ? `${(stage.area_percent * 100).toFixed(1)}%`
+                              : 'No Play'
                             : `${stage.area_win} - ${stage.area_lose}`}
                         </td>
                         <td>
                           {this.state.percent
-                            ? `${stage.yagura_percent.toFixed(2)}`
+                            ? isFinite(stage.yagura_percent)
+                              ? `${(stage.yagura_percent * 100).toFixed(1)}%`
+                              : 'No Play'
                             : `${stage.yagura_win} - ${stage.yagura_lose}`}
                         </td>
                         <td>
                           {this.state.percent
-                            ? `${stage.hoko_percent.toFixed(2)}`
+                            ? isFinite(stage.hoko_percent)
+                              ? `${(stage.hoko_percent * 100).toFixed(1)}%`
+                              : 'No Play'
                             : `${stage.hoko_win} - ${stage.hoko_lose}`}
                         </td>
                         <td>
                           {this.state.percent
-                            ? `${stage.asari_percent.toFixed(2)}`
+                            ? isFinite(stage.asari_percent)
+                              ? `${(stage.asari_percent * 100).toFixed(1)}%`
+                              : 'No Play'
                             : `${stage.asari_win} - ${stage.asari_lose}`}
                         </td>
                         <td>
                           {this.state.percent
-                            ? `${stage.total_percent.toFixed(2)}`
+                            ? isFinite(stage.total_percent)
+                              ? `${(stage.total_percent * 100).toFixed(1)}%`
+                              : 'No Play'
                             : `${stage.total_win} - ${stage.total_lose}`}
                         </td>
                       </tr>
@@ -267,27 +277,37 @@ class StageCard extends React.Component {
                       </th>
                       <td>
                         {this.state.percent
-                          ? `${calcStats.sz_percent.toFixed(2)}`
+                          ? isFinite(calcStats.sz_percent)
+                            ? `${(calcStats.sz_percent * 100).toFixed(1)}%`
+                            : 'No Play'
                           : `${calcStats.sz_win} - ${calcStats.sz_lose}`}
                       </td>
                       <td>
                         {this.state.percent
-                          ? `${calcStats.tc_percent.toFixed(2)}`
+                          ? isFinite(calcStats.tc_percent)
+                            ? `${(calcStats.tc_percent * 100).toFixed(1)}%`
+                            : 'No Play'
                           : `${calcStats.tc_win} - ${calcStats.tc_lose}`}
                       </td>
                       <td>
                         {this.state.percent
-                          ? `${calcStats.rm_percent.toFixed(2)}`
+                          ? isFinite(calcStats.rm_percent)
+                            ? `${(calcStats.rm_percent * 100).toFixed(1)}%`
+                            : 'No Play'
                           : `${calcStats.rm_win} - ${calcStats.rm_lose}`}
                       </td>
                       <td>
                         {this.state.percent
-                          ? `${calcStats.cb_percent.toFixed(2)}`
+                          ? isFinite(calcStats.cb_percent)
+                            ? `${(calcStats.cb_percent * 100).toFixed(1)}%`
+                            : 'No Play'
                           : `${calcStats.cb_win} - ${calcStats.cb_lose}`}
                       </td>
                       <td>
                         {this.state.percent
-                          ? `${calcStats.total_percent.toFixed(2)}`
+                          ? isFinite(calcStats.total_percent)
+                            ? `${(calcStats.total_percent * 100).toFixed(1)}%`
+                            : 'No Play'
                           : `${calcStats.total_win} - ${calcStats.total_lose}`}
                       </td>
                     </tr>

--- a/src/components/stage-card.js
+++ b/src/components/stage-card.js
@@ -233,35 +233,35 @@ class StageCard extends React.Component {
                           {this.state.percent
                             ? isFinite(stage.area_percent)
                               ? `${(stage.area_percent * 100).toFixed(1)}%`
-                              : 'No Play'
+                              : '---'
                             : `${stage.area_win} - ${stage.area_lose}`}
                         </td>
                         <td>
                           {this.state.percent
                             ? isFinite(stage.yagura_percent)
                               ? `${(stage.yagura_percent * 100).toFixed(1)}%`
-                              : 'No Play'
+                              : '---'
                             : `${stage.yagura_win} - ${stage.yagura_lose}`}
                         </td>
                         <td>
                           {this.state.percent
                             ? isFinite(stage.hoko_percent)
                               ? `${(stage.hoko_percent * 100).toFixed(1)}%`
-                              : 'No Play'
+                              : '---'
                             : `${stage.hoko_win} - ${stage.hoko_lose}`}
                         </td>
                         <td>
                           {this.state.percent
                             ? isFinite(stage.asari_percent)
                               ? `${(stage.asari_percent * 100).toFixed(1)}%`
-                              : 'No Play'
+                              : '---'
                             : `${stage.asari_win} - ${stage.asari_lose}`}
                         </td>
                         <td>
                           {this.state.percent
                             ? isFinite(stage.total_percent)
                               ? `${(stage.total_percent * 100).toFixed(1)}%`
-                              : 'No Play'
+                              : '---'
                             : `${stage.total_win} - ${stage.total_lose}`}
                         </td>
                       </tr>
@@ -279,35 +279,35 @@ class StageCard extends React.Component {
                         {this.state.percent
                           ? isFinite(calcStats.sz_percent)
                             ? `${(calcStats.sz_percent * 100).toFixed(1)}%`
-                            : 'No Play'
+                            : '---'
                           : `${calcStats.sz_win} - ${calcStats.sz_lose}`}
                       </td>
                       <td>
                         {this.state.percent
                           ? isFinite(calcStats.tc_percent)
                             ? `${(calcStats.tc_percent * 100).toFixed(1)}%`
-                            : 'No Play'
+                            : '---'
                           : `${calcStats.tc_win} - ${calcStats.tc_lose}`}
                       </td>
                       <td>
                         {this.state.percent
                           ? isFinite(calcStats.rm_percent)
                             ? `${(calcStats.rm_percent * 100).toFixed(1)}%`
-                            : 'No Play'
+                            : '---'
                           : `${calcStats.rm_win} - ${calcStats.rm_lose}`}
                       </td>
                       <td>
                         {this.state.percent
                           ? isFinite(calcStats.cb_percent)
                             ? `${(calcStats.cb_percent * 100).toFixed(1)}%`
-                            : 'No Play'
+                            : '---'
                           : `${calcStats.cb_win} - ${calcStats.cb_lose}`}
                       </td>
                       <td>
                         {this.state.percent
                           ? isFinite(calcStats.total_percent)
                             ? `${(calcStats.total_percent * 100).toFixed(1)}%`
-                            : 'No Play'
+                            : '---'
                           : `${calcStats.total_win} - ${calcStats.total_lose}`}
                       </td>
                     </tr>


### PR DESCRIPTION
The sorting algorithm wouldn't operate correctly when a NaN variable was going through it; I added a few checks and pushed them to the bottom of the list.

Changed the Stage Cards to display from floating numbers to percent format (To one decimal place ex: 99.9%). NaN's are displayed as 'No Play'.

(Clean up from previous PR)