### PR TITLE
Add default rank; Clean up unused imports

### DIFF
--- a/src/components/team-stats-table.js
+++ b/src/components/team-stats-table.js
@@ -62,7 +62,7 @@ const PlayerRow = ({ player, crown }) => {
       </td>
 
       {player.player.udemae ? (
-        <td>{`${player.player.udemae.name}${crown ? '👑' : ''}`}</td>
+        <td>{`${player.player.udemae.name || 'C-'}${crown ? '👑' : ''}`}</td>
       ) : null}
       <td style={{ textAlign: 'center', background: 'darkgrey' }}>
         <Image

--- a/src/schedule.js
+++ b/src/schedule.js
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { Container, Row, Col, Image } from 'react-bootstrap';
+import { Image } from 'react-bootstrap';
 import { FormattedMessage, defineMessages, useIntl } from 'react-intl';
 import { useSplatnet } from './splatnet-provider';
 import './schedule.css';


### PR DESCRIPTION
While playing League match, I noticed that when a player hasn't played any Ranked matches the payload returns null for `player.udemae.name`. The NSO app defaults to C- when this is the case so we can do the same.

### Before

<img width="477" alt="Screen Shot 2020-09-13 at 9 35 59 PM" src="https://user-images.githubusercontent.com/1447644/93044304-3c98b200-f609-11ea-9c51-517e7a5038d8.png">

### After

<img width="487" alt="Screen Shot 2020-09-13 at 9 36 33 PM" src="https://user-images.githubusercontent.com/1447644/93044312-43272980-f609-11ea-92e3-e6132df466ee.png">
