### PR TITLE
Add https to Content Security Policy

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="theme-color" content="#000000">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self' localhost:* app.splatoon2.nintendo.net 'unsafe-inline'">
-    <meta http-equiv="Content-Security-Policy" content="style-src 'self' localhost:* app.splatoon2.nintendo.net 'unsafe-inline'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' localhost:* https://app.splatoon2.nintendo.net 'unsafe-inline'">
+    <meta http-equiv="Content-Security-Policy" content="style-src 'self' localhost:* https://app.splatoon2.nintendo.net 'unsafe-inline'">
     <!--
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/


### PR DESCRIPTION
Fixes https://github.com/hymm/squid-tracks/issues/210

Images not loading over secure protocol due to CSP issue. I'm not exactly sure why this started failing now. My guess is something changed with how Electron evals the CSP between Electron v3 and Electron v9 that was upgraded in `v1.3.3`.

<img width="1658" alt="Screen Shot 2020-09-24 at 3 36 45 PM" src="https://user-images.githubusercontent.com/1447644/94207161-dec36000-fe7b-11ea-96af-8a2fd9fc1692.png">

@hymm 